### PR TITLE
Update Free5GC UPF to latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ The following Debian's packages are required (or their equivalent on your distri
 >[!NOTE]
 > If you intend to use Free5GC’s UPF (with `make set/dataplane/free5gc`),
 > install [Free5CG's GTP5G kernel module](https://github.com/free5gc/gtp5g) on your host.
-> Until [upstream issue](https://github.com/free5gc/go-upf/issues/53) is fixed, and this repository updated, use version v0.8.10 of the driver.
 > Please note that you need to have Linux headers installed on the host to be able to install the module
 > (for example, the package `linux-headers-amd64` on Debian if you are on an amd64 architecture).
 


### PR DESCRIPTION
Tested with gtp5g kernel module version 6a05967f97699a947837cf9497fab1ab2c13aaaaa (latest commit on origin/master)